### PR TITLE
Fix build

### DIFF
--- a/src/_cargo_task_util.rs
+++ b/src/_cargo_task_util.rs
@@ -40,7 +40,7 @@ macro_rules! ct_warn {
 /// format! style helper for printing out fatal messages.
 #[macro_export]
 macro_rules! ct_fatal {
-    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_fatal(&format!($($tt)*)); };
+    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_fatal(&format!($($tt)*)) };
 }
 
 /// takes a result, if the result is error, runs ct_fatal!

--- a/src/_cargo_task_util.rs
+++ b/src/_cargo_task_util.rs
@@ -28,13 +28,13 @@ pub fn ct_env() -> Rc<CTEnv> {
 /// format! style helper for printing out info messages.
 #[macro_export]
 macro_rules! ct_info {
-    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_info(&format!($($tt)*)); };
+    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_info(&format!($($tt)*)) };
 }
 
 /// format! style helper for printing out warn messages.
 #[macro_export]
 macro_rules! ct_warn {
-    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_warn(&format!($($tt)*)); };
+    ($($tt:tt)*) => { $crate::_cargo_task_util::ct_warn(&format!($($tt)*)) };
 }
 
 /// format! style helper for printing out fatal messages.


### PR DESCRIPTION
This crate doesn't build with the latest Rust version, due to a new warning which is turned into an error by `#![deny(warnings)]`.